### PR TITLE
Various differentials output fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ More details can be found here: https://patsy.readthedocs.io/en/latest/formulas.
 **Q**. That's cool!  How many variables can be pass into the formula?
 
 **A**. That depends on the number of samples you have -- the rule of thumb is to only have about 10% of your samples.
-So if you have 100 samples, you should not have a formula with more than 10 variables.  This measure needs to be used with caution, since the number of categories will also impact this.  A categorical variable with *k* categories counts as *k-1* variables, so a column with 3 categories will be represented as 2 variables in the model.  Continuous variables will only count as 1 variable.  You can sometime migitate this risk with the `--beta-prior` parameter.
+So if you have 100 samples, you should not have a formula with more than 10 variables.  This measure needs to be used with caution, since the number of categories will also impact this.  A categorical variable with *k* categories counts as *k-1* variables, so a column with 3 categories will be represented as 2 variables in the model.  Continuous variables will only count as 1 variable.  You can sometime migitate this risk with the `--differential-prior` parameter.
 
-**Q**. Wait a minute, what do you mean that I can migitate overfitting with the `--beta-prior`?
+**Q**. Wait a minute, what do you mean that I can migitate overfitting with the `--differential-prior`?
 
 **A**. When I mean overfitting, I'm referring to scenarios when the models attempts to memorize data points rather than
 building predictive models to undercover biological patterns.  See https://xkcd.com/1725/
 
-The `--beta-prior` command specifies the width of the prior distribution of the coefficients. For `--beta-prior 1`, this means 99% of rankings (given in differentials.tsv) are within -3 and +3 (log fold change). The higher beta-prior is, the more parameters can have bigger changes, so you want to keep this relatively small.  If you see overfitting (accuracy and fit increasing over iterations in tensorboard) you may consider reducing the beta-prior in order to reduce the parameter space.
+The `--differential-prior` command specifies the width of the prior distribution of the coefficients. For `--differential-prior 1`, this means 99% of rankings (given in differentials.tsv) are within -3 and +3 (log fold change). The higher differential-prior is, the more parameters can have bigger changes, so you want to keep this relatively small.  If you see overfitting (accuracy and fit increasing over iterations in tensorboard) you may consider reducing the differential-prior in order to reduce the parameter space.
 
 **Q**. What's up with the `--training-column` argument?
 
@@ -148,7 +148,7 @@ The y-axis is MINUS log probability of the model actually fitting - so LOWER is 
 
 It's recommended to start with a small formula (few variables in the model) and increase from there, because it makes debuggin easier. If your graphs are going down but not exponentially and not plateauing, you should consider increasing the number of iterations by increasing `--epoch`
 
-If your graphs are going down but then going back up, this suggests overfitting; try reducing the number of variables in your formula, or reducing beta prior. As a rule of thumb, you should try to keep the number of metadata categories less than 10% the number of samples (e.g. for 100 samples, no more than 10 metadata categories).
+If your graphs are going down but then going back up, this suggests overfitting; try reducing the number of variables in your formula, or reducing `--differential-prior`. As a rule of thumb, you should try to keep the number of metadata categories less than 10% the number of samples (e.g. for 100 samples, no more than 10 metadata categories).
 
 So basically we want to futz around with the parameters until we see two nice exponential decay graphs.
 Once you have that, we can view the differentials.tsv output to look at the ranks.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ songbird multinomial \
 	--metadata-file <your-training-metadata>.txt \
 	--summary-dir <results>
 ```
-All of the coefficients are stored under `<results>/beta.csv`.
+All of the coefficients are stored under `<results>/differentials.tsv`.
 
 The most important aspect of the coefficients are the rankings, or the ordering of the coefficients within a covariate.
 
@@ -51,17 +51,17 @@ https://github.com/knightlab-analyses/reference-frames
 
 **A** There are 3 major types of files to note
 
-`beta.csv`: This contains the ranks of the microbes for a given metadata categories.  The higher the rank, the more associated it is with that category.  The lower the rank, the more negatively associated it is with a category.  The recommended way to view these files is to sort the microbes within a given column in this file and investigate the top/bottom microbes with the highest/lowest ranks.
+`differentials.tsv`: This contains the ranks of the microbes for a given metadata categories.  The higher the rank, the more associated it is with that category.  The lower the rank, the more negatively associated it is with a category.  The recommended way to view these files is to sort the microbes within a given column in this file and investigate the top/bottom microbes with the highest/lowest ranks.
 
 The first column is the features (if you plugged in a q2 table, then you can look up the sequence or bacterial name by merging with rep-seqs or taxonomy, respectively).  Once you have identified the microbes that change the most and least (have the highest and lowest coefficients) you can plot the log ratio of these microbes across metadata categories or gradients!
 
-note: continuous variables should only produce ONE column in the beta.csv file, if not, something is wrong with the metadata (maybe not all numbers or something)
+note: continuous variables should only produce ONE column in the differentials.tsv file, if not, something is wrong with the metadata (maybe not all numbers or something)
 
-`checkpoint` : this points to checkpoint files -- this can be used for saving intermediate results.  This is more important for jobs that will take days to run, where the models parameter can be investigated while the program is running, rather than waiting for `beta.csv` to be written.
+`checkpoint` : this points to checkpoint files -- this can be used for saving intermediate results.  This is more important for jobs that will take days to run, where the models parameter can be investigated while the program is running, rather than waiting for `differentials.tsv` to be written.
 
 `events.out.tfevents.*` : These files are what is being read into Tensorboard - more discussion on this later.
 
-**Q**. Why do I have so many columns in my beta.csv even when I'm only using one continuous variable?
+**Q**. Why do I have so many columns in my differentials.tsv even when I'm only using one continuous variable?
 
 **A**. A couple things could be happening.  First, the standalone songbird script assumes that the mapping files only have 1 line for the header, so you need to reformat.  In addition, it could be that there are other values in that column (i.e. Not Applicable, NA, nan, ...), and these sorts of values need to be removed in order to properly perform songbird regression on continuous variables. For continuous variables, only numeric characters are accepted otherwise songbird assumes this is a categorical value.
 
@@ -87,7 +87,7 @@ So if you have 100 samples, you should not have a formula with more than 10 vari
 **A**. When I mean overfitting, I'm referring to scenarios when the models attempts to memorize data points rather than
 building predictive models to undercover biological patterns.  See https://xkcd.com/1725/
 
-The `--beta-prior` command specifies the width of the prior distribution of the coefficients. For `--beta-prior 1`, this means 99% of rankings (given in beta.csv) are within -3 and +3 (log fold change). The higher beta-prior is, the more parameters can have bigger changes, so you want to keep this relatively small.  If you see overfitting (accuracy and fit increasing over iterations in tensorboard) you may consider reducing the beta-prior in order to reduce the parameter space.
+The `--beta-prior` command specifies the width of the prior distribution of the coefficients. For `--beta-prior 1`, this means 99% of rankings (given in differentials.tsv) are within -3 and +3 (log fold change). The higher beta-prior is, the more parameters can have bigger changes, so you want to keep this relatively small.  If you see overfitting (accuracy and fit increasing over iterations in tensorboard) you may consider reducing the beta-prior in order to reduce the parameter space.
 
 **Q**. What's up with the `--training-column` argument?
 
@@ -151,7 +151,7 @@ It's recommended to start with a small formula (few variables in the model) and 
 If your graphs are going down but then going back up, this suggests overfitting; try reducing the number of variables in your formula, or reducing beta prior. As a rule of thumb, you should try to keep the number of metadata categories less than 10% the number of samples (e.g. for 100 samples, no more than 10 metadata categories).
 
 So basically we want to futz around with the parameters until we see two nice exponential decay graphs.
-Once you have that, we can view the beta.csv output to look at the ranks.
+Once you have that, we can view the differentials.tsv output to look at the ranks.
 
 
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ qiime songbird multinomial \
 	--i-table redsea.biom.qza \
 	--m-metadata-file data/redsea/redsea_metadata.txt \
 	--p-formula "Depth+Temperature+Salinity+Oxygen+Fluorescence+Nitrate" \
-	--o-differential differentials.qza \
+	--o-differentials differentials.qza \
 	--o-regression-stats regression-stats.qza \
 	--o-regression-biplot regression-biplot.qza
 ```
@@ -212,7 +212,7 @@ qiime songbird multinomial \
     --p-formula "1" \
     --p-epochs 5000 \
     --p-summary-interval 1 \
-    --o-differential baseline-diff.qza \
+    --o-differentials baseline-diff.qza \
     --o-regression-stats baseline-stats.qza \
     --o-regression-biplot baseline-biplot.qza
 

--- a/data/run.sh
+++ b/data/run.sh
@@ -13,39 +13,52 @@ songbird multinomial \
     --formula $formula \
     --min-feature-count 10 \
     --batch-size 3 \
-    --epoch 10000 \
+    --epochs 10000 \
     --num-random-test-examples 5 \
     --summary-interval 1
 
-
-
-# Options:
-#   --input-biom TEXT               Input abundances
-#   --metadata-file TEXT            Input microbial abundances for testing
-#   --formula TEXT                  statistical formula specifying the
-#                                   covariates to test for.
-#   --training-column TEXT          The column in the metadata file used to
-#                                   specify training and testing. These columns
-#                                   should be specifically labeled (Train) and
-#                                   (Test)
-#   --num-random-test-examples INTEGER
-#                                   Number of random training examples if
-#                                   --training-column is not specified
-#   --epoch INTEGER                 Number of epochs to train
-#   --batch-size INTEGER            Size of mini-batch
-#   --beta-prior FLOAT              Width of normal prior for the coefficients
-#                                   Smaller values will regularize parameters
-#                                   towards zero. Values must be greater than 0.
-#   --learning-rate FLOAT           Gradient descent decay rate.
-#   --clipnorm FLOAT                Gradient clipping size.
-#   --min-sample-count INTEGER      The minimum number of counts a sample needs
-#                                   for it to be included in the analysis
-#   --min-feature-count INTEGER     The minimum number of counts a feature needs
-#                                   for it to be included in the analysis
-#   --checkpoint-interval INTEGER   Number of seconds before a saving a
-#                                   checkpoint
-#   --summary-interval INTEGER      Number of seconds before a storing a
-#                                   summary.
-#   --summary-dir TEXT              Summary directory to save cross validation
-#                                   results.
-#   --help                          Show this message and exit.
+#Usage: songbird multinomial [OPTIONS]
+#
+#Options:
+#  --input-biom TEXT               Input abundances  [required]
+#  --metadata-file TEXT            Sample metadata table with covariates of
+#                                  interest.  [required]
+#  --formula TEXT                  Statistical formula specifying the
+#                                  covariates to test for.  [required]
+#  --training-column TEXT          The column in the metadata file used to
+#                                  specify training and testing. These columns
+#                                  should be specifically labeled (Train) and
+#                                  (Test)
+#  --num-random-test-examples INTEGER
+#                                  Number of random training examples if
+#                                  --training-column is not specified
+#                                  [default: 5]
+#  --epochs INTEGER                The number of total number of iterations
+#                                  over the entire dataset  [default: 1000]
+#  --batch-size INTEGER            Size of mini-batch  [default: 5]
+#  --differential-prior FLOAT      Width of normal prior for the
+#                                  `differentials`, or the coefficients of the
+#                                  multinomial regression. Smaller values will
+#                                  force the coefficients towards zero. Values
+#                                  must be greater than 0.  [default: 1.0]
+#  --learning-rate FLOAT           Gradient descent decay rate.  [default:
+#                                  0.001]
+#  --clipnorm FLOAT                Gradient clipping size.  [default: 10.0]
+#  --min-sample-count INTEGER      The minimum number of counts a sample needs
+#                                  for it to be included in the analysis
+#                                  [default: 1000]
+#  --min-feature-count INTEGER     The minimum number of counts a feature needs
+#                                  for it to be included in the analysis
+#                                  [default: 5]
+#  --checkpoint-interval INTEGER   Number of seconds before a saving a
+#                                  checkpoint  [default: 3600]
+#  --summary-interval INTEGER      Number of seconds before a storing a
+#                                  summary.  [default: 60]
+#  --summary-dir TEXT              Summary directory to save regression
+#                                  results. This will include a table of
+#                                  differentials under `differentials.tsv` that
+#                                  can be ranked, in addition to summaries that
+#                                  can be loaded into Tensorboard and
+#                                  checkpoints for recovering parameters during
+#                                  runtime.  [default: summarydir]
+#  --help                          Show this message and exit.

--- a/scripts/songbird
+++ b/scripts/songbird
@@ -57,7 +57,7 @@ def songbird():
 @click.option('--summary-dir', default='summarydir', show_default=True,
               help='Summary directory to save regression results. '
               'This will include a table of differentials under '
-              '`differentials.csv` that can be ranked, in addition '
+              '`differentials.tsv` that can be ranked, in addition '
               'to summaries that can be loaded into Tensorboard and '
               'checkpoints for recovering parameters during runtime.')
 def multinomial(input_biom, metadata_file, formula, training_column,
@@ -103,7 +103,7 @@ def multinomial(input_biom, metadata_file, formula, training_column,
 
     pd.DataFrame(
         beta_.T, columns=md_ids, index=obs_ids,
-    ).to_csv(os.path.join(summary_dir, 'differentials.csv'))
+    ).to_csv(os.path.join(summary_dir, 'differentials.tsv'), sep='\t')
 
 
 if __name__ == '__main__':

--- a/scripts/songbird
+++ b/scripts/songbird
@@ -16,11 +16,11 @@ def songbird():
 
 
 @songbird.command()
-@click.option('--input-biom', show_default=True,
+@click.option('--input-biom', show_default=True, required=True,
               help='Input abundances')
-@click.option('--metadata-file', show_default=True,
+@click.option('--metadata-file', show_default=True, required=True,
               help='Sample metadata table with covariates of interest.')
-@click.option('--formula', show_default=True,
+@click.option('--formula', show_default=True, required=True,
               help=('Statistical formula specifying the covariates '
                     'to test for.'))
 @click.option('--training-column', default=None, show_default=True,

--- a/songbird/q2/_method.py
+++ b/songbird/q2/_method.py
@@ -61,7 +61,7 @@ def multinomial(table: biom.Table,
 
     beta_ = clr(clr_inv(np.hstack((np.zeros((model.p, 1)), model.B))))
 
-    differential = pd.DataFrame(
+    differentials = pd.DataFrame(
         beta_.T, columns=md_ids, index=obs_ids,
     )
     convergence_stats = pd.DataFrame(
@@ -85,13 +85,13 @@ def multinomial(table: biom.Table,
     convergence_stats['iteration'] = c
 
     # regression biplot
-    if differential.shape[-1] > 1:
-        u, s, v = np.linalg.svd(differential)
+    if differentials.shape[-1] > 1:
+        u, s, v = np.linalg.svd(differentials)
         pc_ids = ['PC%d' % i for i in range(len(s))]
         samples = pd.DataFrame(u[:, :len(s)] @ np.diag(s),
-                               columns=pc_ids, index=differential.index)
+                               columns=pc_ids, index=differentials.index)
         features = pd.DataFrame(v.T[:, :len(s)],
-                                columns=pc_ids, index=differential.columns)
+                                columns=pc_ids, index=differentials.columns)
         short_method_name = 'regression_biplot'
         long_method_name = 'Multinomial regression biplot'
         eigvals = pd.Series(s, index=pc_ids)
@@ -104,4 +104,4 @@ def multinomial(table: biom.Table,
         # this is to handle the edge case with only intercepts
         biplot = OrdinationResults('', '', pd.Series(), pd.DataFrame())
 
-    return differential, qiime2.Metadata(convergence_stats), biplot
+    return differentials, qiime2.Metadata(convergence_stats), biplot

--- a/songbird/q2/_stats.py
+++ b/songbird/q2/_stats.py
@@ -27,4 +27,4 @@ class DifferentialFormat(model.TextFileFormat):
 
 
 DifferentialDirFmt = model.SingleFileDirectoryFormat(
-    'DifferentialDirFmt', 'differential.tsv', DifferentialFormat)
+    'DifferentialDirFmt', 'differentials.tsv', DifferentialFormat)

--- a/songbird/q2/_transformer.py
+++ b/songbird/q2/_transformer.py
@@ -20,7 +20,7 @@ def _2(obj: qiime2.Metadata) -> SongbirdStatsFormat:
 @plugin.register_transformer
 def _3(ff: DifferentialFormat) -> pd.DataFrame:
     df = pd.read_csv(str(ff), sep='\t', comment='#', skip_blank_lines=True,
-                     header=True, dtype=object)
+                     header=0, dtype=object)
     return df
 
 

--- a/songbird/q2/_transformer.py
+++ b/songbird/q2/_transformer.py
@@ -20,7 +20,7 @@ def _2(obj: qiime2.Metadata) -> SongbirdStatsFormat:
 @plugin.register_transformer
 def _3(ff: DifferentialFormat) -> pd.DataFrame:
     df = pd.read_csv(str(ff), sep='\t', comment='#', skip_blank_lines=True,
-                     header=0, dtype=object)
+                     header=0, dtype=object, index_col=0)
     return df
 
 

--- a/songbird/q2/plugin_setup.py
+++ b/songbird/q2/plugin_setup.py
@@ -54,7 +54,7 @@ plugin.methods.register_function(
         'summary_interval': Int
     },
     outputs=[
-        ('differential', FeatureData[Differential]),
+        ('differentials', FeatureData[Differential]),
         ('regression_stats', SampleData[SongbirdStats]),
         ('regression_biplot', PCoAResults % Properties('biplot'))
     ],
@@ -62,7 +62,7 @@ plugin.methods.register_function(
         'table': 'Input table of counts.',
     },
     output_descriptions={
-        'differential': ('Output differentials learned from the '
+        'differentials': ('Output differentials learned from the '
                          'multinomial regression.'),
         'regression_stats': ('Summary information about the loss '
                              'and cross validation error over iterations.'),

--- a/songbird/q2/plugin_setup.py
+++ b/songbird/q2/plugin_setup.py
@@ -63,7 +63,7 @@ plugin.methods.register_function(
     },
     output_descriptions={
         'differentials': ('Output differentials learned from the '
-                         'multinomial regression.'),
+                          'multinomial regression.'),
         'regression_stats': ('Summary information about the loss '
                              'and cross validation error over iterations.'),
         'regression_biplot': ('A biplot of the regression coefficients')


### PR DESCRIPTION
- Makes standalone and Q2 output more consistent (both fundamentally output a "differentials" TSV now)
- Fixes a bug in the transformer used to read the differentials TSV file (the wrong type of argument for `header` was being used, which caused QIIME 2 to crash when applying this transformer)
- Uses the feature ID of the differentials TSV as its index when loading it as a DataFrame (makes working with this artifact programmatically more intuitive)
- Updated the README accordingly (replaces uses of "beta.csv" with "differentials.tsv," etc.)