### PR TITLE
BLD: Add tqdm and tf requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(name='songbird',
           'scikit-bio>=0.5.1',
           'scikit-learn',
           'biom-format',
-          'seaborn',
           'tqdm',
           'tensorflow > 1.5'
       ],

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,9 @@ setup(name='songbird',
           'scikit-bio>=0.5.1',
           'scikit-learn',
           'biom-format',
-          'seaborn'
+          'seaborn',
+          'tqdm',
+          'tensorflow > 1.5'
       ],
       classifiers=classifiers,
       license='BSD-3-Clause',


### PR DESCRIPTION
Fixes #48 -- this makes songbird installable via `pip install -e .`