### PR TITLE
Including tensorflow as an explicit dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(name='songbird',
           'patsy',
           'scikit-bio>=0.5.1',
           'biom-format',
-          'tqdm'
+          'tqdm',
+          'tensorflow>=1.4'
       ],
       classifiers=classifiers,
       license='BSD-3-Clause',


### PR DESCRIPTION
This is so that users who don't have tensorflow will automatically have it fetched when pip installing songbird.

CC @fedarko 