### PR TITLE
BLD: Add missing citations file to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,5 +71,5 @@ setup(name='songbird',
       entry_points={
           'qiime2.plugins': ['q2-songbird=songbird.q2.plugin_setup:plugin']
       },
-      package_data={},
+      package_data={'songbird': ['citations.bib']},
       zip_safe=False)


### PR DESCRIPTION
Otherwise loading the QIIME2 plugin would lead to the following error:

```python-traceback
Traceback (most recent call last):
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/bin/qiime", line 11, in <module>
    sys.exit(qiime())
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/q2cli/builtin/dev.py", line 31, in refresh_cache
    import q2cli.core.cache
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/q2cli/core/cache.py", line 403, in <module>
    CACHE = DeploymentCache()
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/q2cli/core/cache.py", line 61, in __init__
    self._state = self._get_cached_state(refresh=refresh)
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/q2cli/core/cache.py", line 107, in _get_cached_state
    self._cache_current_state(current_requirements)
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/q2cli/core/cache.py", line 200, in _cache_current_state
    state = self._get_current_state()
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/q2cli/core/cache.py", line 238, in _get_current_state
    plugin_manager = qiime2.sdk.PluginManager()
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/qiime2/sdk/plugin_manager.py", line 44, in __new__
    self._init()
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/qiime2/sdk/plugin_manager.py", line 59, in _init
    plugin = entry_point.load()
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2434, in load
    return self.resolve()
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2440, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/songbird/q2/plugin_setup.py", line 23, in <module>
    citations = qiime2.plugin.Citations.load('citations.bib', package='songbird')
  File "/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/qiime2/core/cite.py", line 30, in load
    with open(path) as fh:
FileNotFoundError: [Errno 2] No such file or directory: '/Users/redacted/miniconda3/envs/qiime2-2019.7/lib/python3.6/site-packages/songbird/citations.bib'
```