### PR TITLE
ENH: Set random seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # songbird changelog
 
 ## Version 1.0.2-dev
+Added ability to set random seed for CLI and sets fixed random seeds for qiime2 []()
+
 Correcting matching between metadata and biom table and clarifying the min-feature-count parameter [#99](https://github.com/biocore/songbird/pull/99)
 
 Added Tensorboard's HParams functionality to standalone [#95](https://github.com/biocore/songbird/pull/95)

--- a/scripts/songbird
+++ b/scripts/songbird
@@ -152,9 +152,15 @@ def multinomial(
                'learning_rate': learning_rate,
                'min_sample_count': min_sample_count,
                'min_feature_count': min_feature_count,
-               'split_seed': split_seed,
-               'tf_seed': tf_seed,
                }
+    if split_seed is not None:
+        hparams.update({
+            'split_seed': split_seed,
+        })
+    if tf_seed is not None:
+        hparams.update({
+            'tf_seed': tf_seed,
+        })
 
     # split up training and testing
     trainX, testX, trainY, testY = split_training(

--- a/scripts/songbird
+++ b/scripts/songbird
@@ -100,16 +100,11 @@ def songbird():
     help=DESCS["summary-dir"],
 )
 @click.option(
-    "--split-seed",
-    default=DEFAULTS["split-seed"],
+    "--random-seed",
+    default=DEFAULTS["random-seed"],
     show_default=True,
-    help=DESCS["split-seed"]
-)
-@click.option(
-    "--tf-seed",
-    default=DEFAULTS["tf-seed"],
-    show_default=True,
-    help=DESCS["tf-seed"]
+    help=DESCS["random-seed"],
+    type=int,
 )
 def multinomial(
     input_biom,
@@ -127,8 +122,7 @@ def multinomial(
     checkpoint_interval,
     summary_interval,
     summary_dir,
-    split_seed,
-    tf_seed,
+    random_seed,
 ):
     # load metadata and tables
     metadata = read_metadata(metadata_file)
@@ -153,13 +147,9 @@ def multinomial(
                'min_sample_count': min_sample_count,
                'min_feature_count': min_feature_count,
                }
-    if split_seed is not None:
+    if random_seed is not None:
         hparams.update({
-            'split_seed': split_seed,
-        })
-    if tf_seed is not None:
-        hparams.update({
-            'tf_seed': tf_seed,
+            'random_seed': random_seed,
         })
 
     # split up training and testing
@@ -169,7 +159,7 @@ def multinomial(
         design,
         training_column,
         num_random_test_examples,
-        seed=split_seed,
+        seed=random_seed,
     )
 
     # initialize and train the model
@@ -182,8 +172,8 @@ def multinomial(
     )
     with tf.Graph().as_default(), tf.Session() as session:
         # set the tf random seed
-        if tf_seed is not None:
-            tf.set_random_seed(int(tf_seed))
+        if random_seed is not None:
+            tf.set_random_seed(random_seed)
 
         model(session, trainX, trainY, testX, testY)
 

--- a/scripts/songbird
+++ b/scripts/songbird
@@ -99,6 +99,18 @@ def songbird():
     show_default=True,
     help=DESCS["summary-dir"],
 )
+@click.option(
+    "--split-seed",
+    default=DEFAULTS["split-seed"],
+    show_default=True,
+    help=DESCS["split-seed"]
+)
+@click.option(
+    "--tf-seed",
+    default=DEFAULTS["tf-seed"],
+    show_default=True,
+    help=DESCS["tf-seed"]
+)
 def multinomial(
     input_biom,
     metadata_file,
@@ -115,6 +127,8 @@ def multinomial(
     checkpoint_interval,
     summary_interval,
     summary_dir,
+    split_seed,
+    tf_seed,
 ):
     # load metadata and tables
     metadata = read_metadata(metadata_file)
@@ -138,17 +152,21 @@ def multinomial(
                'learning_rate': learning_rate,
                'min_sample_count': min_sample_count,
                'min_feature_count': min_feature_count,
+               'split_seed': split_seed,
+               'tf_seed': tf_seed,
                }
 
+    # split up training and testing
     trainX, testX, trainY, testY = split_training(
         dense_table,
         metadata,
         design,
         training_column,
         num_random_test_examples,
+        seed=split_seed,
     )
 
-    # split up training and testing
+    # initialize and train the model
     model = MultRegression(
         learning_rate=learning_rate,
         clipnorm=clipnorm,
@@ -157,6 +175,10 @@ def multinomial(
         save_path=summary_dir,
     )
     with tf.Graph().as_default(), tf.Session() as session:
+        # set the tf random seed
+        if tf_seed is not None:
+            tf.set_random_seed(int(tf_seed))
+
         model(session, trainX, trainY, testX, testY)
 
         model.fit(

--- a/scripts/test_songbird_cli.py
+++ b/scripts/test_songbird_cli.py
@@ -42,7 +42,7 @@ class TestSongbirdCLI(unittest.TestCase):
             error = Exception('Command failed with non-zero exit code')
             raise error .with_traceback(ex.__traceback__)
 
-    def test_cli_set_split_seed_int(self):
+    def test_cli_set_set_seed_int(self):
         runner = CliRunner()
         test_args = ['--input-biom', 'data/redsea/redsea.biom',
                      '--metadata-file', 'data/redsea/redsea_metadata.txt',
@@ -53,7 +53,7 @@ class TestSongbirdCLI(unittest.TestCase):
                      '--differential-prior', '0.5',
                      '--summary-interval', '1',
                      '--summary-dir', self.path,
-                     '--split-seed', 42,
+                     '--random-seed', 42,
                      ]
 
         result = runner.invoke(songbird.multinomial, test_args)
@@ -64,7 +64,7 @@ class TestSongbirdCLI(unittest.TestCase):
             error = Exception('Command failed with non-zero exit code')
             raise error .with_traceback(ex.__traceback__)
 
-    def test_cli_set_split_seed_None(self):
+    def test_cli_set_random_seed_None(self):
         runner = CliRunner()
         test_args = ['--input-biom', 'data/redsea/redsea.biom',
                      '--metadata-file', 'data/redsea/redsea_metadata.txt',
@@ -75,53 +75,7 @@ class TestSongbirdCLI(unittest.TestCase):
                      '--differential-prior', '0.5',
                      '--summary-interval', '1',
                      '--summary-dir', self.path,
-                     '--split-seed', None,
-                     ]
-
-        result = runner.invoke(songbird.multinomial, test_args)
-        try:
-            self.assertEqual(0, result.exit_code)
-        except AssertionError:
-            ex = result.exception
-            error = Exception('Command failed with non-zero exit code')
-            raise error .with_traceback(ex.__traceback__)
-
-    def test_cli_set_tf_seed_int(self):
-        runner = CliRunner()
-        test_args = ['--input-biom', 'data/redsea/redsea.biom',
-                     '--metadata-file', 'data/redsea/redsea_metadata.txt',
-                     '--formula',
-                     'Depth+Temperature+Salinity+Oxygen+Fluorescence'
-                     '+Nitrate',
-                     '--epochs', '100',
-                     '--differential-prior', '0.5',
-                     '--summary-interval', '1',
-                     '--summary-dir', self.path,
-                     '--split-seed', None,
-                     '--tf-seed', 42,
-                     ]
-
-        result = runner.invoke(songbird.multinomial, test_args)
-        try:
-            self.assertEqual(0, result.exit_code)
-        except AssertionError:
-            ex = result.exception
-            error = Exception('Command failed with non-zero exit code')
-            raise error .with_traceback(ex.__traceback__)
-
-    def test_cli_set_split_seed_tf_seed_int(self):
-        runner = CliRunner()
-        test_args = ['--input-biom', 'data/redsea/redsea.biom',
-                     '--metadata-file', 'data/redsea/redsea_metadata.txt',
-                     '--formula',
-                     'Depth+Temperature+Salinity+Oxygen+Fluorescence'
-                     '+Nitrate',
-                     '--epochs', '100',
-                     '--differential-prior', '0.5',
-                     '--summary-interval', '1',
-                     '--summary-dir', self.path,
-                     '--tf-seed', 42,
-                     '--split-seed', 42,
+                     '--random-seed', None,
                      ]
 
         result = runner.invoke(songbird.multinomial, test_args)

--- a/scripts/test_songbird_cli.py
+++ b/scripts/test_songbird_cli.py
@@ -22,7 +22,7 @@ class TestSongbirdCLI(unittest.TestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.path)
 
-    def test_cli(self):
+    def test_cli_no_seed_set(self):
         runner = CliRunner()
         test_args = ['--input-biom', 'data/redsea/redsea.biom',
                      '--metadata-file', 'data/redsea/redsea_metadata.txt',
@@ -33,6 +33,72 @@ class TestSongbirdCLI(unittest.TestCase):
                      '--differential-prior', '0.5',
                      '--summary-interval', '1',
                      '--summary-dir', self.path]
+
+        result = runner.invoke(songbird.multinomial, test_args)
+        try:
+            self.assertEqual(0, result.exit_code)
+        except AssertionError:
+            ex = result.exception
+            error = Exception('Command failed with non-zero exit code')
+            raise error .with_traceback(ex.__traceback__)
+
+    def test_cli_set_split_seed_int(self):
+        runner = CliRunner()
+        test_args = ['--input-biom', 'data/redsea/redsea.biom',
+                     '--metadata-file', 'data/redsea/redsea_metadata.txt',
+                     '--formula',
+                     'Depth+Temperature+Salinity+Oxygen+Fluorescence'
+                     '+Nitrate',
+                     '--epochs', '100',
+                     '--differential-prior', '0.5',
+                     '--summary-interval', '1',
+                     '--summary-dir', self.path,
+                     '--split-seed', 42,
+                     ]
+
+        result = runner.invoke(songbird.multinomial, test_args)
+        try:
+            self.assertEqual(0, result.exit_code)
+        except AssertionError:
+            ex = result.exception
+            error = Exception('Command failed with non-zero exit code')
+            raise error .with_traceback(ex.__traceback__)
+
+    def test_cli_set_split_seed_None(self):
+        runner = CliRunner()
+        test_args = ['--input-biom', 'data/redsea/redsea.biom',
+                     '--metadata-file', 'data/redsea/redsea_metadata.txt',
+                     '--formula',
+                     'Depth+Temperature+Salinity+Oxygen+Fluorescence'
+                     '+Nitrate',
+                     '--epochs', '100',
+                     '--differential-prior', '0.5',
+                     '--summary-interval', '1',
+                     '--summary-dir', self.path,
+                     '--split-seed', None,
+                     ]
+
+        result = runner.invoke(songbird.multinomial, test_args)
+        try:
+            self.assertEqual(0, result.exit_code)
+        except AssertionError:
+            ex = result.exception
+            error = Exception('Command failed with non-zero exit code')
+            raise error .with_traceback(ex.__traceback__)
+
+    def test_cli_set_tf_seed_int(self):
+        runner = CliRunner()
+        test_args = ['--input-biom', 'data/redsea/redsea.biom',
+                     '--metadata-file', 'data/redsea/redsea_metadata.txt',
+                     '--formula',
+                     'Depth+Temperature+Salinity+Oxygen+Fluorescence'
+                     '+Nitrate',
+                     '--epochs', '100',
+                     '--differential-prior', '0.5',
+                     '--summary-interval', '1',
+                     '--summary-dir', self.path,
+                     '--tf-seed', 42,
+                     ]
 
         result = runner.invoke(songbird.multinomial, test_args)
         try:

--- a/scripts/test_songbird_cli.py
+++ b/scripts/test_songbird_cli.py
@@ -97,7 +97,31 @@ class TestSongbirdCLI(unittest.TestCase):
                      '--differential-prior', '0.5',
                      '--summary-interval', '1',
                      '--summary-dir', self.path,
+                     '--split-seed', None,
                      '--tf-seed', 42,
+                     ]
+
+        result = runner.invoke(songbird.multinomial, test_args)
+        try:
+            self.assertEqual(0, result.exit_code)
+        except AssertionError:
+            ex = result.exception
+            error = Exception('Command failed with non-zero exit code')
+            raise error .with_traceback(ex.__traceback__)
+
+    def test_cli_set_split_seed_tf_seed_int(self):
+        runner = CliRunner()
+        test_args = ['--input-biom', 'data/redsea/redsea.biom',
+                     '--metadata-file', 'data/redsea/redsea_metadata.txt',
+                     '--formula',
+                     'Depth+Temperature+Salinity+Oxygen+Fluorescence'
+                     '+Nitrate',
+                     '--epochs', '100',
+                     '--differential-prior', '0.5',
+                     '--summary-interval', '1',
+                     '--summary-dir', self.path,
+                     '--tf-seed', 42,
+                     '--split-seed', 42,
                      ]
 
         result = runner.invoke(songbird.multinomial, test_args)

--- a/songbird/parameter_info.py
+++ b/songbird/parameter_info.py
@@ -45,6 +45,13 @@ DESCS = {
         'to summaries that can be loaded into Tensorboard and '
         'checkpoints for recovering parameters during runtime.'
     ),
+    "split-seed": (
+        'The number to use as a seed for splitting data into training and '
+        'test sets.'
+    ),
+    "tf-seed": (
+        'The number to use as a random seed in TensorFlow.'
+    ),
 }
 
 DEFAULTS = {
@@ -60,4 +67,6 @@ DEFAULTS = {
     "checkpoint-interval": 3600,
     "summary-interval": 10,
     "summary-dir": "summarydir",
+    "split-seed": 0,
+    "tf-seed": None,
 }

--- a/songbird/parameter_info.py
+++ b/songbird/parameter_info.py
@@ -45,12 +45,9 @@ DESCS = {
         'to summaries that can be loaded into Tensorboard and '
         'checkpoints for recovering parameters during runtime.'
     ),
-    "split-seed": (
-        'The number to use as a seed for splitting data into training and '
-        'test sets.'
-    ),
-    "tf-seed": (
-        'The number to use as a random seed in TensorFlow.'
+    "random-seed": (
+        'The number to used to receive consistent results for the random  '
+        'processes in the fitting procedure.'
     ),
 }
 
@@ -67,6 +64,5 @@ DEFAULTS = {
     "checkpoint-interval": 3600,
     "summary-interval": 10,
     "summary-dir": "summarydir",
-    "split-seed": 0,
-    "tf-seed": None,
+    "random-seed": 0,
 }

--- a/songbird/q2/_method.py
+++ b/songbird/q2/_method.py
@@ -43,7 +43,8 @@ def multinomial(table: biom.Table,
     # split up training and testing
     trainX, testX, trainY, testY = split_training(
         dense_table, metadata, design,
-        training_column, num_random_test_examples
+        training_column, num_random_test_examples,
+        seed=0,
     )
 
     model = MultRegression(learning_rate=learning_rate, clipnorm=clipnorm,
@@ -51,6 +52,7 @@ def multinomial(table: biom.Table,
                            batch_size=batch_size,
                            save_path=None)
     with tf.Graph().as_default(), tf.Session() as session:
+        tf.set_random_seed(0)
         model(session, trainX, trainY, testX, testY)
 
         loss, cv, its = model.fit(

--- a/songbird/q2/_method.py
+++ b/songbird/q2/_method.py
@@ -25,7 +25,9 @@ def multinomial(table: biom.Table,
                 clipnorm: float = DEFAULTS["clipnorm"],
                 min_sample_count: int = DEFAULTS["min-sample-count"],
                 min_feature_count: int = DEFAULTS["min-feature-count"],
-                summary_interval: int = DEFAULTS["summary-interval"]) -> (
+                summary_interval: int = DEFAULTS["summary-interval"],
+                random_seed: int = DEFAULTS["random-seed"],
+                ) -> (
                     pd.DataFrame, qiime2.Metadata, skbio.OrdinationResults
                 ):
 
@@ -44,7 +46,7 @@ def multinomial(table: biom.Table,
     trainX, testX, trainY, testY = split_training(
         dense_table, metadata, design,
         training_column, num_random_test_examples,
-        seed=0,
+        seed=random_seed,
     )
 
     model = MultRegression(learning_rate=learning_rate, clipnorm=clipnorm,
@@ -52,7 +54,7 @@ def multinomial(table: biom.Table,
                            batch_size=batch_size,
                            save_path=None)
     with tf.Graph().as_default(), tf.Session() as session:
-        tf.set_random_seed(0)
+        tf.set_random_seed(random_seed)
         model(session, trainX, trainY, testX, testY)
 
         loss, cv, its = model.fit(

--- a/songbird/q2/plugin_setup.py
+++ b/songbird/q2/plugin_setup.py
@@ -49,7 +49,8 @@ plugin.methods.register_function(
         'clipnorm': Float,
         'min_sample_count': Int,
         'min_feature_count': Int,
-        'summary_interval': Int
+        'summary_interval': Int,
+        'random_seed': Int,
     },
     outputs=[
         ('differentials', FeatureData[Differential]),
@@ -79,6 +80,7 @@ plugin.methods.register_function(
         "min_sample_count": DESCS["min-sample-count"],
         "min_feature_count": DESCS["min-feature-count"],
         "summary_interval": DESCS["summary-interval"],
+        "random_seed": DESCS["random-seed"],
     },
     name='Multinomial regression',
     description=("Performs multinomial regression and calculates "

--- a/songbird/q2/tests/test_method.py
+++ b/songbird/q2/tests/test_method.py
@@ -75,6 +75,5 @@ class TestMultinomial(unittest.TestCase):
         npt.assert_array_equal(res_biplot1.features, res_biplot2.features)
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/songbird/q2/tests/test_method.py
+++ b/songbird/q2/tests/test_method.py
@@ -1,7 +1,6 @@
 import qiime2
 import unittest
 import numpy as np
-import pandas as pd
 import tensorflow as tf
 from songbird.q2._method import multinomial
 from songbird.util import random_multinomial_model

--- a/songbird/q2/tests/test_method.py
+++ b/songbird/q2/tests/test_method.py
@@ -1,6 +1,7 @@
 import qiime2
 import unittest
 import numpy as np
+import pandas as pd
 import tensorflow as tf
 from songbird.q2._method import multinomial
 from songbird.util import random_multinomial_model
@@ -48,6 +49,31 @@ class TestMultinomial(unittest.TestCase):
 
         npt.assert_allclose(exp_beta, res_beta.T, atol=0.6, rtol=0.6)
         self.assertGreater(len(res_stats.to_dataframe().index), 1)
+
+    def test_fit_consistency(self):
+        md = self.md
+
+        md.name = 'sampleid'
+        md = qiime2.Metadata(md)
+
+        res_beta1, res_stats1, res_biplot1 = multinomial(
+            table=self.table, metadata=md,
+            min_sample_count=0, min_feature_count=0,
+            formula="X", epochs=1000)
+
+        res_beta2, res_stats2, res_biplot2 = multinomial(
+            table=self.table, metadata=md,
+            min_sample_count=0, min_feature_count=0,
+            formula="X", epochs=1000)
+
+        npt.assert_array_equal(res_beta1, res_beta2)
+        end_res_stats1 = res_stats1.to_dataframe().iloc[-1]
+        end_res_stats2 = res_stats2.to_dataframe().iloc[-1]
+        npt.assert_array_equal(end_res_stats1, end_res_stats2)
+        npt.assert_array_equal(res_biplot1.eigvals, res_biplot2.eigvals)
+        npt.assert_array_equal(res_biplot1.samples, res_biplot2.samples)
+        npt.assert_array_equal(res_biplot1.features, res_biplot2.features)
+
 
 
 if __name__ == "__main__":

--- a/songbird/util.py
+++ b/songbird/util.py
@@ -176,9 +176,10 @@ def match_and_filter(table, metadata, formula,
 
 
 def split_training(dense_table, metadata, design, training_column=None,
-                   num_random_test_examples=10):
+                   num_random_test_examples=10, seed=None):
 
     if training_column is None:
+        np.random.seed(seed)
         idx = np.random.random(design.shape[0])
         i = np.argsort(idx)[num_random_test_examples]
 


### PR DESCRIPTION
# Songbird random seeds

## Current behavior:

When I run:
```
$ songbird multinomial \
    --input-biom data/redsea/redsea.biom \
    --metadata-file data/redsea/redsea_metadata.txt \
    --formula "1" \
    --epochs 1000 \
    --differential-prior 0.5 \
    --summary-interval 1 \
    --summary-dir logdir/model1
$ songbird multinomial \
    --input-biom data/redsea/redsea.biom \
    --metadata-file data/redsea/redsea_metadata.txt \
    --formula "1" \
    --epochs 1000 \
    --differential-prior 0.5 \
    --summary-interval 1 \
    --summary-dir logdir/model2
```

I get something like the following, where the cv-error converges to different values and the training error is updated differently:

<img width="854" alt="Screen Shot 2019-12-16 at 2 20 06 PM" src="https://user-images.githubusercontent.com/19470970/70935883-34c2c780-200f-11ea-9274-0996ff8fe188.png">



## Further exploration:

So I provided an option to fix the seed for making train/test splits:
```
$ songbird multinomial \
    --input-biom data/redsea/redsea.biom \
    --metadata-file data/redsea/redsea_metadata.txt \
    --formula "1" \
    --epochs 1000 \
    --differential-prior 0.5 \
    --summary-interval 1 \
    --summary-dir logdir/model3 \
    --seed 42
$ songbird multinomial \
    --input-biom data/redsea/redsea.biom \
    --metadata-file data/redsea/redsea_metadata.txt \
    --formula "1" \
    --epochs 1000 \
    --differential-prior 0.5 \
    --summary-interval 1 \
    --summary-dir logdir/model4 \
    --seed 42
```

![Screen Shot 2019-12-13 at 10 47 00 AM](https://user-images.githubusercontent.com/19470970/70935766-f1685900-200e-11ea-82b6-37f7aa57623b.png)

And now the models converge to approximately the same value.
However, as there a still variations in their training updates. So I provided a way to fix the seed that tensorflow uses as well.

```
$ songbird multinomial \
    --input-biom data/redsea/redsea.biom \
    --metadata-file data/redsea/redsea_metadata.txt \
    --formula "1" \
    --epochs 1000 \
    --differential-prior 0.5 \
    --summary-interval 1 \
    --summary-dir logdir/model5 \
    --split-seed 42 \
    --tf-seed 22
$ songbird multinomial \
    --input-biom data/redsea/redsea.biom \
    --metadata-file data/redsea/redsea_metadata.txt \
    --formula "1" \
    --epochs 1000 \
    --differential-prior 0.5 \
    --summary-interval 1 \
    --summary-dir logdir/model6 \
    --split-seed 42 \
    --tf-seed 22
```

And now it is identical between runs:
![Screen Shot 2019-12-13 at 11 12 50 AM](https://user-images.githubusercontent.com/19470970/70935812-0cd36400-200f-11ea-9e23-2444dfec0a12.png)


## Proposed behavior:

When the above commands are run, I should at least get the same CV score, but furthermore, it should be possible to fix the entire training process.

In order to fix this I propose the following solution:

* For QIIME2 plugin:
  * Have a fixed random seed for both tensorflow and train/test split
    - this ensures that all results that come out of Q2 for the same data are directly comparable, and the same optimization results are achieved every time
    - additionally removes the need for a user to understand how to appropriately set their on seeds
* For the standalone interface:
  * Have a random seed option for the train/test split and tensorflow, that are independent of each other
  * Set a default seed for train/test split
    * again ensures that results are directly comparable by default
  * Have the option to set a seed for tensorflow, but is not set by default
    * This one is less of a big deal since the loss function is convex, but it is nice to be able to set if you want to recreate the exact same process

## Summary of changes:
* add `--split-seed` and `--tf-seed` option to the songbird CLI (and update parameter info accordingly)
* add a unit test to `scripts.test_songbird_cli` that verifies that different combinations of these flags still run on the CLI
* Set both random seeds to 0 in the Q2 plugin
* add a test to the Q2 plugin that verifies subsequent calls on the same inputs have the exact same output
