### PR TITLE
ENH: Q2 summary interval allow float

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ language: python
 env:
   - PYVERSION=3.5
 before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update
-  - sudo apt-get install gcc-4.9
-  - sudo apt-get install --only-upgrade libstdc++6
+  - sudo apt-get -y install gcc-4.9
+  - sudo apt-get -y install --only-upgrade libstdc++6
   - export MPLBACKEND='Agg'
   - wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - export MINICONDA_PREFIX="$HOME/miniconda"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ language: python
 env:
   - PYVERSION=3.5
 before_install:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update
+  - sudo apt-get install gcc-4.9
+  - sudo apt-get install --only-upgrade libstdc++6
   - export MPLBACKEND='Agg'
   - wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - export MINICONDA_PREFIX="$HOME/miniconda"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 env:
   - PYVERSION=3.5
 before_install:
+  # see https://github.com/lhelontra/tensorflow-on-arm/issues/13#issuecomment-489296444
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update
   - sudo apt-get -y install gcc-4.9

--- a/songbird/multinomial.py
+++ b/songbird/multinomial.py
@@ -142,7 +142,7 @@ class MultRegression(object):
         ----------
         epochs : int
            Number of epochs to train
-        summary_interval : int
+        summary_interval : float
            Number of seconds until a summary is recorded
         checkpoint_interval : int
            Number of seconds until a checkpoint is recorded

--- a/songbird/q2/plugin_setup.py
+++ b/songbird/q2/plugin_setup.py
@@ -49,7 +49,7 @@ plugin.methods.register_function(
         'clipnorm': Float,
         'min_sample_count': Int,
         'min_feature_count': Int,
-        'summary_interval': Int,
+        'summary_interval': Float,
         'random_seed': Int,
     },
     outputs=[

--- a/songbird/q2/tests/test_method.py
+++ b/songbird/q2/tests/test_method.py
@@ -8,6 +8,7 @@ from songbird.util import random_multinomial_model
 from skbio import OrdinationResults
 from skbio.stats.composition import clr, clr_inv
 import numpy.testing as npt
+import pandas as pd
 from songbird.q2.plugin_setup import plugin as songbird_plugin
 
 
@@ -88,15 +89,29 @@ class TestMultinomial(unittest.TestCase):
         q2_table = qiime2.Artifact.import_data('FeatureTable[Frequency]',
                                                self.table)
 
-        res_beta, res_stats, res_biplot = multregression(
+        q2_res_beta, q2_res_stats, q2_res_biplot = multregression(
             table=q2_table, metadata=md,
             min_sample_count=0, min_feature_count=0,
             formula="X", epochs=1000,
             summary_interval=0.5,
         )
 
-        # test biplot
-        self.assertIsInstance(res_biplot, OrdinationResults)
+        try:
+            res_biplot = q2_res_biplot.view(OrdinationResults)
+        except Exception:
+            raise AssertionError('res_biplot unable to be coerced to '
+                                 'OrdinationResults')
+        try:
+            res_beta = q2_res_beta.view(pd.DataFrame)
+        except Exception:
+            raise AssertionError('res_beta unable to be coerced to '
+                                 'pd.DataFrame')
+        try:
+            res_stats = q2_res_stats.view(qiime2.Metadata)
+        except Exception:
+            raise AssertionError('res_stats unable to be coerced to '
+                                 'qiime2.Metadata')
+
         u = res_biplot.samples.values
         v = res_biplot.features.values.T
         npt.assert_allclose(u @ v, res_beta.values,

--- a/songbird/q2/tests/test_method.py
+++ b/songbird/q2/tests/test_method.py
@@ -8,6 +8,7 @@ from songbird.util import random_multinomial_model
 from skbio import OrdinationResults
 from skbio.stats.composition import clr, clr_inv
 import numpy.testing as npt
+from songbird.q2.plugin_setup import plugin as songbird_plugin
 
 
 class TestMultinomial(unittest.TestCase):
@@ -72,6 +73,37 @@ class TestMultinomial(unittest.TestCase):
         npt.assert_array_equal(res_biplot1.eigvals, res_biplot2.eigvals)
         npt.assert_array_equal(res_biplot1.samples, res_biplot2.samples)
         npt.assert_array_equal(res_biplot1.features, res_biplot2.features)
+
+    def test_fit_float_summary_interval(self):
+        tf.set_random_seed(0)
+        md = self.md
+
+        multregression = songbird_plugin.actions['multinomial']
+
+        md.name = 'sampleid'
+        md = qiime2.Metadata(md)
+
+        exp_beta = clr(clr_inv(np.hstack((np.zeros((2, 1)), self.beta.T))))
+
+        q2_table = qiime2.Artifact.import_data('FeatureTable[Frequency]',
+                                               self.table)
+
+        res_beta, res_stats, res_biplot = multregression(
+            table=q2_table, metadata=md,
+            min_sample_count=0, min_feature_count=0,
+            formula="X", epochs=1000,
+            summary_interval=0.5,
+        )
+
+        # test biplot
+        self.assertIsInstance(res_biplot, OrdinationResults)
+        u = res_biplot.samples.values
+        v = res_biplot.features.values.T
+        npt.assert_allclose(u @ v, res_beta.values,
+                            atol=0.5, rtol=0.5)
+
+        npt.assert_allclose(exp_beta, res_beta.T, atol=0.6, rtol=0.6)
+        self.assertGreater(len(res_stats.to_dataframe().index), 1)
 
 
 if __name__ == "__main__":

--- a/songbird/q2/tests/test_method.py
+++ b/songbird/q2/tests/test_method.py
@@ -84,6 +84,7 @@ class TestMultinomial(unittest.TestCase):
         md.name = 'sampleid'
         md = qiime2.Metadata(md)
 
+        # See issue #31
         exp_beta = clr(clr_inv(np.hstack((np.zeros((2, 1)), self.beta.T))))
 
         q2_table = qiime2.Artifact.import_data('FeatureTable[Frequency]',
@@ -96,6 +97,7 @@ class TestMultinomial(unittest.TestCase):
             summary_interval=0.5,
         )
 
+        # try-except is for helpful error message if q2-coercion fails
         try:
             res_biplot = q2_res_biplot.view(OrdinationResults)
         except Exception:


### PR DESCRIPTION
Adds the ability to use a float for `summary-interval` in Q2.

Would be nice to get more granular feedback for models that run very quickly, such as below:

![image](https://user-images.githubusercontent.com/19470970/73105255-5c7a3a80-3ead-11ea-8803-e6f767065680.png)

Where the model converge quickly (just a couple seconds) so there are only a very few number of updates before convergence.