### PR TITLE
REL: fix typo re: TF vsn + elaborate in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ specifying formulas, _Q<sup>2</sup>_ scores, etc.
 [#103](https://github.com/biocore/songbird/pull/103),
 [#109](https://github.com/biocore/songbird/pull/109)
 
-Pinned TensorFlow's version to be at least 1.15.2 and less than 2. This may be
-a temporary solution, depending on [how we move forward from here](https://github.com/biocore/songbird/issues/110).
-[#109](https://github.com/biocore/songbird/pull/109)
+Pinned TensorFlow's version to be at least 1.15 and less than 2. This is due in
+part to recent security issues that have been identified in TensorFlow
+([1](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2019-002.md),
+[2](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2020-001.md)) -- the latter of these does not seem to have been addressed yet on conda, but neither of these issues should have an impact on normal usage of Songbird.
+
+  - Pinning the TensorFlow version in this way may be a temporary solution, depending on [how we move forward from here](https://github.com/biocore/songbird/issues/110).
+  - [#109](https://github.com/biocore/songbird/pull/109)
 
 ## Version 1.0.1 (2019-10-16)
 Enable duplicate metadata ids [#89](https://github.com/biocore/songbird/pull/89)


### PR DESCRIPTION
Minor updates to the changelog that I wanted to run by someone, rather than unilaterally change myself :)

- I initially wrote `1.15.2` as the minimum TensorFlow version, even though conda doesn't seem to have that available yet (they only have `1.15` as the latest v1 release [as far as I can tell](https://anaconda.org/anaconda/tensorflow/files)). We do set `1.15.2` as the minimum through pip, though. (This brings to mind the whole "merging dependency info into a single file" thing... maintaining the 3 files at once is gonna cause more problems like this.)

- Also, figured it'd be good to mention the "security advisories" that the TF team released since we last updated Songbird. Neither of these seem like they'd impact the normal usage of TF through Songbird (let me know if you think this isn't the case), but mentioning them seemed like the right thing to do here.