### PR TITLE
REL: Relax minimum TF version to 1.15 from 1.15.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(name='songbird',
           'scikit-bio>=0.5.1',
           'biom-format',
           'tqdm',
-          'tensorflow>=1.15.2,<2'
+          'tensorflow>=1.15,<2'
       ],
       classifiers=classifiers,
       license='BSD-3-Clause',


### PR DESCRIPTION
Closes #122: Should fix second problem described there.

The current `setup.py` in the pip package is breaking the conda-forge install, annoyingly enough. I think it would be best if we could push out a minor release of Songbird on pip to resolve this.