### PR TITLE
Replace conda-forge with pip in Q2 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ before installing Songbird. In your QIIME 2 conda environment, you can install S
 running:
 
 ```
-conda install songbird -c conda-forge
+pip install songbird
 ```
 
 Next, run the following command to get QIIME 2 to "recognize" Songbird:


### PR DESCRIPTION
This will not actually address #126, but it'll at least allow users to get past the problem for the time being